### PR TITLE
docs(cheatsheet) [AS] Add meaningful alt-text to image examples

### DIFF
--- a/Markdown-Cheatsheet.md
+++ b/Markdown-Cheatsheet.md
@@ -177,10 +177,10 @@ Some text to show that the reference links can follow later.
 Here's our logo (hover to see the title text):
 
 Inline-style: 
-![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
+![Markdown Here logo](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
 
 Reference-style: 
-![alt text][logo]
+![Markdown Here logo][logo]
 
 [logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 2"
 ```
@@ -188,10 +188,10 @@ Reference-style:
 Here's our logo (hover to see the title text):
 
 Inline-style: 
-![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
+![Markdown Here logo](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
 
 Reference-style: 
-![alt text][logo]
+![Markdown Here logo][logo]
 
 [logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 2"
 

--- a/Markdown-Here-Cheatsheet.md
+++ b/Markdown-Here-Cheatsheet.md
@@ -164,10 +164,10 @@ Some text to show that the reference links can follow later.
 Here's our logo (hover to see the title text):
 
 Inline-style: 
-![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
+![Markdown Here logo](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
 
 Reference-style: 
-![alt text][logo]
+![Markdown Here logo][logo]
 
 [logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 2"
 ```
@@ -175,10 +175,10 @@ Reference-style:
 Here's our logo (hover to see the title text):
 
 Inline-style: 
-![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
+![Markdown Here logo](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
 
 Reference-style: 
-![alt text][logo]
+![Markdown Here logo][logo]
 
 [logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 2"
 


### PR DESCRIPTION
Adds meaningful alt-text as a concrete example to follow.

Refs for guidelines:
 - http://w3c.github.io/html/semantics-embedded-content.html#alt-text
 - https://webaim.org/techniques/alttext/